### PR TITLE
Fixes js modules to work, adds gitignore, deletes jest.config.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/LeetCode/sum.js
+++ b/LeetCode/sum.js
@@ -1,4 +1,0 @@
-function sum(a, b) {
-  return a + b;
-}
-module.exports = sum;

--- a/LeetCode/sum.test.js
+++ b/LeetCode/sum.test.js
@@ -1,5 +1,0 @@
-const sum = require("./sum");
-
-test("adds 1 + 2 to equal 3", () => {
-  expect(sum(1, 2)).toBe(3);
-});

--- a/LeetCode/validAnagram.js
+++ b/LeetCode/validAnagram.js
@@ -35,8 +35,6 @@ export function validAnagram(s, t) {
   return true;
 }
 
-module.exports = validAnagram;
-
 // function validAnagram (s, t){
 //   if (s.length !== t.length) return false;
 

--- a/LeetCode/validAnagram.test.js
+++ b/LeetCode/validAnagram.test.js
@@ -1,4 +1,4 @@
-import { validAnagram } from "./validAnagram";
+import { validAnagram } from "./validAnagram.js";
 // const validAnagram = require("./validAnagram");
 
 test("cattt and tac to be false", () => {

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,0 @@
-// jest.config.js
-export const config = {
-  transformIgnorePatterns: ["node_modules/(?!(axios)/)"],
-};
-export default config;

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "My journey with Leetcode style data structures and algo problems",
   "main": "index.js",
   "scripts": {
-    "test": "jest"
+    "test": "node --experimental-vm-modules ./node_modules/jest/bin/jest.js"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
@helloimivy

To fix the js modules issues, I had to
1. Delete the lingering old syntax: `module.exports = validAnagram;`
2. The normal "jest" command doesnt support modules so I had to use their experimental binary command: `node --experimental-vm-modules ./node_modules/jest/bin/jest.js`
3. And add the .js extension to our import paths `import { validAnagram } from "./validAnagram.js"`

Other changes:
- Deleted sum.js, sum.test.js, and jest.config.js as they are no longer needed
- Added a .gitignore to stop node_modules from being uploaded